### PR TITLE
Fix submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 !.gitignore
 !.gitmodules
 !system/
-!elms-styles/
 !elmsln-logos/
 !instances/
 !instances/_development/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 !.gitmodules
 !system/
 !elms-styles
-!elmsln-logos/
+!elmsln-logos
 !instances/
 !instances/_development/
 !instances/_development/config-example/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.gitmodules
 !system/
+!elms-styles
 !elmsln-logos/
 !instances/
 !instances/_development/

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "elms-styles"]
 	path = elms-styles
 	url = https://github.com/elmsln/elms-styles.git
+[submodule "elmsln-logos"]
+	path = elmsln-logos
+	url = https://github.com/elmsln/elmsln-logos.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "elmsln-config-travis-ci"]
     path = instances/_development/config-travis-ci
     url = https://github.com/elmsln/elmsln-config-travis-ci.git
+[submodule "elms-styles"]
+	path = elms-styles
+	url = https://github.com/elmsln/elms-styles.git


### PR DESCRIPTION
Was getting the following error when attempting to recursively clone the elmsln-developer repo.

```
No submodule mapping found in .gitmodules for path 'elms-styles'
```

I removed the old implementation and added elms-styles and elmsln-logo as submodules.
